### PR TITLE
Add lid detection for Retroid Pocket Flip 2

### DIFF
--- a/workspace/all/common/udev_input.h
+++ b/workspace/all/common/udev_input.h
@@ -61,4 +61,15 @@ const char* udev_find_device_by_name(const char* device_name);
  */
 void udev_close_all(int* fds, int count);
 
+/**
+ * Open an input device by name.
+ *
+ * Finds and opens a specific input device matching the given name.
+ * Useful for opening dedicated hardware like lid switches.
+ *
+ * @param device_name Exact device name to search for (e.g., "gpio-keys-lid")
+ * @return File descriptor on success, -1 if device not found or open failed
+ */
+int udev_open_device_by_name(const char* device_name);
+
 #endif // UDEV_INPUT_H


### PR DESCRIPTION
Implements sleep/wake on lid close/open using the gpio-keys-lid input device and SW_LID events. Key changes:

- Fix udev_find_device_by_name to read name from parent device
- Add udev_open_device_by_name helper function
- Handle EV_SW lid events in PLAT_pollInput and PLAT_shouldWake
- Add PLAT_initLid to detect sensor and read initial state
- Add device name variants for Flip2 (with/without space)